### PR TITLE
Add an integration test for the jetty module

### DIFF
--- a/webbeans-jetty9/pom.xml
+++ b/webbeans-jetty9/pom.xml
@@ -98,6 +98,12 @@
             <artifactId>openwebbeans-web</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.openwebbeans</groupId>
+            <artifactId>openwebbeans-el22</artifactId>
+            <version>${project.version}</version>
+            <scope>optional</scope>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/webbeans-jetty9/pom.xml
+++ b/webbeans-jetty9/pom.xml
@@ -214,6 +214,7 @@
                     <filterProperties>
                         <jettyVersion>${jetty.version}</jettyVersion>
                         <repository.proxy.url>${repository.proxy.url}</repository.proxy.url>
+                        <local.repository.path>${project.build.directory}/local-repo</local.repository.path>
                     </filterProperties>
                     <pomIncludes>
                         <pomInclude>*/pom.xml</pomInclude>

--- a/webbeans-jetty9/pom.xml
+++ b/webbeans-jetty9/pom.xml
@@ -129,30 +129,102 @@
 
     <build>
         <plugins>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-assembly-plugin</artifactId>
-            <dependencies>
-                <dependency>
-                    <groupId>org.eclipse.jetty.toolchain</groupId>
-                    <artifactId>jetty-assembly-descriptors</artifactId>
-                    <version>1.0</version>
-                </dependency>
-            </dependencies>
-            <executions>
-                <execution>
-                    <phase>package</phase>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <!-- TODO switch back to jetty descriptors once https://github.com/eclipse/jetty.project/issues/3514
+                       is resolved -->
+                <!--<dependencies>-->
+                <!--    <dependency>-->
+                <!--        <groupId>org.eclipse.jetty.toolchain</groupId>-->
+                <!--        <artifactId>jetty-assembly-descriptors</artifactId>-->
+                <!--        <version>1.0</version>-->
+                <!--    </dependency>-->
+                <!--</dependencies>-->
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <!--<descriptorRefs>-->
+                            <!--    <descriptorRef>config</descriptorRef>-->
+                            <!--</descriptorRefs>-->
+                            <descriptors>
+                                <descriptor>src/main/assembly/config.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!-- NOTE may need to switch to a different plugin if
+                       https://github.com/eclipse/jetty.project/issues/3514 provides a solution for transitive
+                       dependencies -->
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/config</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/config</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                            <useDefaultDelimiters>false</useDefaultDelimiters>
+                            <delimiters>
+                                <delimiter>@</delimiter>
+                            </delimiters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>mrm-maven-plugin</artifactId>
+                <version>1.2.0</version>
+                <configuration>
+                    <propertyName>repository.proxy.url</propertyName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>start</goal>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <configuration>
+                    <debug>false</debug><!-- unless we want to debug the jetty-maven-plugin-->
+                    <projectsDirectory>src/it</projectsDirectory>
+                    <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                    <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+                    <settingsFile>src/it/settings.xml</settingsFile>
+                    <filterProperties>
+                        <jettyVersion>${jetty.version}</jettyVersion>
+                        <repository.proxy.url>${repository.proxy.url}</repository.proxy.url>
+                    </filterProperties>
+                    <pomIncludes>
+                        <pomInclude>*/pom.xml</pomInclude>
+                    </pomIncludes>
                     <goals>
-                        <goal>single</goal>
+                        <goal>install</goal>
                     </goals>
-                    <configuration>
-                        <descriptorRefs>
-                            <descriptorRef>config</descriptorRef>
-                        </descriptorRefs>
-                    </configuration>
-                </execution>
-            </executions>
-        </plugin>
+                    <!-- when run from the command line, we are likely debugging just one, so stream -->
+                    <streamLogs>true</streamLogs>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -166,20 +238,8 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-invoker-plugin</artifactId>
                         <configuration>
-                            <debug>false</debug><!-- unless we want to debug the jetty-maven-plugin-->
-                            <projectsDirectory>src/it</projectsDirectory>
-                            <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
-                            <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
-                            <settingsFile>src/it/settings.xml</settingsFile>
-                            <filterProperties>
-                                <jettyVersion>${jetty.version}</jettyVersion>
-                            </filterProperties>
-                            <pomIncludes>
-                                <pomInclude>*/pom.xml</pomInclude>
-                            </pomIncludes>
-                            <goals>
-                                <goal>install</goal>
-                            </goals>
+                            <!-- we are the profile running all tests, send the logs to file only -->
+                            <streamLogs>false</streamLogs>
                         </configuration>
                         <executions>
                             <execution>

--- a/webbeans-jetty9/src/it/module/pom.xml
+++ b/webbeans-jetty9/src/it/module/pom.xml
@@ -1,0 +1,303 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements. See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version
+        2.0 (the "License"); you may not use this file except in compliance
+        with the License. You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+        applicable law or agreed to in writing, software distributed under the
+        License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+        CONDITIONS OF ANY KIND, either express or implied. See the License for
+        the specific language governing permissions and limitations under the
+        License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.openwebbeans</groupId>
+        <artifactId>openwebbeans</artifactId>
+        <version>@project.version@</version>
+    </parent>
+
+    <groupId>org.apache.openwebbeans.it</groupId>
+    <artifactId>openwebbeans-jetty9-it-servletinjection</artifactId>
+    <version>@project.version@</version>
+    <packaging>war</packaging>
+    <name>Jetty 9 plugin IT</name>
+
+    <properties>
+        <jetty.port.it>9081</jetty.port.it>
+        <jstl.version>1.2</jstl.version>
+        <projectStage>Development</projectStage>
+    </properties>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jcdi_2.0_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-atinject_1.0_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-servlet_3.0_spec</artifactId>
+            <version>1.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <finalName>owbjetty9it</finalName>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-maven-plugin</artifactId>
+                    <version>@jettyVersion@</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.openwebbeans</groupId>
+                            <artifactId>openwebbeans-spi</artifactId>
+                            <version>@project.version@</version>
+                        </dependency>
+
+                        <dependency>
+                            <groupId>org.apache.openwebbeans</groupId>
+                            <artifactId>openwebbeans-impl</artifactId>
+                            <version>@project.version@</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.openwebbeans</groupId>
+                            <artifactId>openwebbeans-web</artifactId>
+                            <version>@project.version@</version>
+                        </dependency>
+
+                        <dependency>
+                            <groupId>org.apache.openwebbeans</groupId>
+                            <artifactId>openwebbeans-jetty9</artifactId>
+                            <version>@project.version@</version>
+                        </dependency>
+
+                        <dependency>
+                            <groupId>org.apache.geronimo.specs</groupId>
+                            <artifactId>geronimo-jcdi_2.0_spec</artifactId>
+                            <version>1.0</version>
+                        </dependency>
+
+                        <dependency>
+                            <groupId>org.apache.geronimo.specs</groupId>
+                            <artifactId>geronimo-atinject_1.0_spec</artifactId>
+                            <version>1.0</version>
+                        </dependency>
+
+                        <dependency>
+                            <groupId>org.apache.geronimo.specs</groupId>
+                            <artifactId>geronimo-interceptor_1.2_spec</artifactId>
+                            <version>1.0</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>jetty-distribution</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.eclipse.jetty</groupId>
+                                    <artifactId>jetty-distribution</artifactId>
+                                    <version>@jettyVersion@</version>
+                                    <type>zip</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                    <excludes>*/demo-base/**</excludes>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>@project.groupId@</groupId>
+                                    <artifactId>@project.artifactId@</artifactId>
+                                    <version>@project.version@</version>
+                                    <type>jar</type>
+                                    <classifier>config</classifier>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/jetty-distribution-@jettyVersion@</outputDirectory>
+                                    <excludes>META-INF/**</excludes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-jetty.base</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/jetty-template</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.directory}/jetty-distribution-@jettyVersion@</directory>
+                                    <includes>start.jar</includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <id>enable-module</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>java</executable>
+                            <arguments>
+                                <argument>-jar</argument>
+                                <argument>${project.build.directory}/jetty-distribution-@jettyVersion@/start.jar</argument>
+                                <argument>--create-startd</argument>
+                                <argument>--create-files</argument>
+                                <argument>--add-to-start=plus</argument>
+                                <argument>--add-to-start=apache-jsp</argument>
+                                <argument>--add-to-start=apache-jstl</argument>
+                                <argument>--add-to-start=apache-owb</argument>
+                                <argument>maven.repo.uri=@repository.proxy.url@</argument>
+                                <argument>--approve-all-licenses</argument>
+                                <argument>jetty.home=${project.build.directory}/jetty-distribution-@jettyVersion@</argument>
+                                <argument>jetty.base=${project.build.directory}/jetty-template</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.11</version>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>verify</id>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <configuration>
+                    <webApp>
+                        <contextPath>/${project.build.finalName}</contextPath>
+                        <configurationClasses>
+                            <configurationClass>org.eclipse.jetty.maven.plugin.MavenWebInfConfiguration</configurationClass>
+                            <configurationClass>org.eclipse.jetty.webapp.WebXmlConfiguration</configurationClass>
+                            <configurationClass>org.eclipse.jetty.webapp.MetaInfConfiguration</configurationClass>
+                            <configurationClass>org.eclipse.jetty.webapp.FragmentConfiguration</configurationClass>
+                            <configurationClass>org.eclipse.jetty.plus.webapp.EnvConfiguration</configurationClass>
+                            <configurationClass>org.eclipse.jetty.plus.webapp.PlusConfiguration</configurationClass>
+                            <configurationClass>org.eclipse.jetty.annotations.AnnotationConfiguration</configurationClass>
+                            <configurationClass>org.apache.webbeans.web.jetty9.OwbConfiguration</configurationClass>
+                            <configurationClass>org.eclipse.jetty.webapp.JettyWebXmlConfiguration</configurationClass>
+                        </configurationClasses>
+                    </webApp>
+                    <jvmArgs>-Dorg.apache.myfaces.PROJECT_STAGE=${projectStage} -Dfaces.PROJECT_STAGE=${projectStage}</jvmArgs>
+                    <waitForChild>false</waitForChild>
+                    <stopKey>foo</stopKey>
+                    <stopPort>9999</stopPort>
+                    <jettyBase>${project.build.directory}/jetty-template</jettyBase>
+                    <jettyHome>${project.build.directory}/jetty-distribution-@jettyVersion@</jettyHome>
+                    <jettyProperties>
+                        <jettyProperty>jetty.http.port=${jetty.port.it}</jettyProperty>
+                        <jettyProperty>maven.repo.uri=@repository.proxy.url@</jettyProperty>
+                    </jettyProperties>
+                    <modules>
+                        <module>apache-jsp</module>
+                        <module>apache-jstl</module>
+                        <module>apache-owb</module>
+                    </modules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>start-jetty</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run-distro</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop-jetty</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/webbeans-jetty9/src/it/module/pom.xml
+++ b/webbeans-jetty9/src/it/module/pom.xml
@@ -87,50 +87,7 @@
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-maven-plugin</artifactId>
                     <version>@jettyVersion@</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.openwebbeans</groupId>
-                            <artifactId>openwebbeans-spi</artifactId>
-                            <version>@project.version@</version>
-                        </dependency>
-
-                        <dependency>
-                            <groupId>org.apache.openwebbeans</groupId>
-                            <artifactId>openwebbeans-impl</artifactId>
-                            <version>@project.version@</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.apache.openwebbeans</groupId>
-                            <artifactId>openwebbeans-web</artifactId>
-                            <version>@project.version@</version>
-                        </dependency>
-
-                        <dependency>
-                            <groupId>org.apache.openwebbeans</groupId>
-                            <artifactId>openwebbeans-jetty9</artifactId>
-                            <version>@project.version@</version>
-                        </dependency>
-
-                        <dependency>
-                            <groupId>org.apache.geronimo.specs</groupId>
-                            <artifactId>geronimo-jcdi_2.0_spec</artifactId>
-                            <version>1.0</version>
-                        </dependency>
-
-                        <dependency>
-                            <groupId>org.apache.geronimo.specs</groupId>
-                            <artifactId>geronimo-atinject_1.0_spec</artifactId>
-                            <version>1.0</version>
-                        </dependency>
-
-                        <dependency>
-                            <groupId>org.apache.geronimo.specs</groupId>
-                            <artifactId>geronimo-interceptor_1.2_spec</artifactId>
-                            <version>1.0</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
-
             </plugins>
         </pluginManagement>
 
@@ -262,6 +219,7 @@
                     <jettyProperties>
                         <jettyProperty>jetty.http.port=${jetty.port.it}</jettyProperty>
                         <jettyProperty>maven.repo.uri=@repository.proxy.url@</jettyProperty>
+                        <jettyProperty>maven.local.repo=@local.repository.path@</jettyProperty>
                     </jettyProperties>
                     <modules>
                         <module>apache-jsp</module>

--- a/webbeans-jetty9/src/it/module/pom.xml
+++ b/webbeans-jetty9/src/it/module/pom.xml
@@ -252,17 +252,6 @@
                 <configuration>
                     <webApp>
                         <contextPath>/${project.build.finalName}</contextPath>
-                        <configurationClasses>
-                            <configurationClass>org.eclipse.jetty.maven.plugin.MavenWebInfConfiguration</configurationClass>
-                            <configurationClass>org.eclipse.jetty.webapp.WebXmlConfiguration</configurationClass>
-                            <configurationClass>org.eclipse.jetty.webapp.MetaInfConfiguration</configurationClass>
-                            <configurationClass>org.eclipse.jetty.webapp.FragmentConfiguration</configurationClass>
-                            <configurationClass>org.eclipse.jetty.plus.webapp.EnvConfiguration</configurationClass>
-                            <configurationClass>org.eclipse.jetty.plus.webapp.PlusConfiguration</configurationClass>
-                            <configurationClass>org.eclipse.jetty.annotations.AnnotationConfiguration</configurationClass>
-                            <configurationClass>org.apache.webbeans.web.jetty9.OwbConfiguration</configurationClass>
-                            <configurationClass>org.eclipse.jetty.webapp.JettyWebXmlConfiguration</configurationClass>
-                        </configurationClasses>
                     </webApp>
                     <jvmArgs>-Dorg.apache.myfaces.PROJECT_STAGE=${projectStage} -Dfaces.PROJECT_STAGE=${projectStage}</jvmArgs>
                     <waitForChild>false</waitForChild>

--- a/webbeans-jetty9/src/it/module/pom.xml
+++ b/webbeans-jetty9/src/it/module/pom.xml
@@ -215,7 +215,8 @@
                                 <argument>--add-to-start=apache-jsp</argument>
                                 <argument>--add-to-start=apache-jstl</argument>
                                 <argument>--add-to-start=apache-owb</argument>
-                                <argument>maven.repo.uri=@repository.proxy.url@</argument>
+                                <argument>maven.local.repo=@local.repository.path@</argument>
+                                <argument>maven.repo.uri=@repository.proxy.url@/</argument>
                                 <argument>--approve-all-licenses</argument>
                                 <argument>jetty.home=${project.build.directory}/jetty-distribution-@jettyVersion@</argument>
                                 <argument>jetty.base=${project.build.directory}/jetty-template</argument>

--- a/webbeans-jetty9/src/it/module/src/main/java/org/apache/webbeans/web/jetty9/test/TestBean.java
+++ b/webbeans-jetty9/src/it/module/src/main/java/org/apache/webbeans/web/jetty9/test/TestBean.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.webbeans.web.jetty9.test;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * Test bean which gets used in the TestServlet.
+ */
+@ApplicationScoped
+public class TestBean
+{
+    int i = 4711;
+
+    public int getI()
+    {
+        return i;
+    }
+
+    public void setI(int i)
+    {
+        this.i = i;
+    }
+}

--- a/webbeans-jetty9/src/it/module/src/main/java/org/apache/webbeans/web/jetty9/test/TestServlet.java
+++ b/webbeans-jetty9/src/it/module/src/main/java/org/apache/webbeans/web/jetty9/test/TestServlet.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.webbeans.web.jetty9.test;
+
+import javax.inject.Inject;
+import javax.servlet.Servlet;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.io.IOException;
+
+/**
+ * Dummy Servlet which just checks whether CDI injection works
+ */
+public class TestServlet implements Servlet
+{
+
+    @Inject
+    private TestBean tb;
+
+    public void destroy()
+    {
+        // nothing to do
+    }
+
+    public void init(ServletConfig config) throws ServletException
+    {
+        // nothing to do
+    }
+
+    public ServletConfig getServletConfig()
+    {
+        return null;
+    }
+
+    public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException
+    {
+        if (tb == null || tb.getI() != 4711)
+        {
+            throw new RuntimeException("CDI Injction doesn not work!");
+        }
+    }
+
+    public String getServletInfo()
+    {
+        return null;
+    }
+}

--- a/webbeans-jetty9/src/it/module/src/main/webapp/WEB-INF/beans.xml
+++ b/webbeans-jetty9/src/it/module/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<beans/>

--- a/webbeans-jetty9/src/it/module/src/main/webapp/WEB-INF/web.xml
+++ b/webbeans-jetty9/src/it/module/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<web-app id="owb-it" version="3.0"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+    <servlet>
+        <servlet-name>TestServlet</servlet-name>
+        <servlet-class>org.apache.webbeans.web.jetty9.test.TestServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>TestServlet</servlet-name>
+        <url-pattern>*.test</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/webbeans-jetty9/src/it/module/src/test/java/org/apache/webbeans/web/jetty9/test/OwbJettyPluginIT.java
+++ b/webbeans-jetty9/src/it/module/src/test/java/org/apache/webbeans/web/jetty9/test/OwbJettyPluginIT.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.webbeans.web.jetty9.test;
+
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.lang.StringBuilder;
+
+/**
+ * Simple requests to the jetty installation
+ */
+public class OwbJettyPluginIT
+{
+    @Test
+    public void testJettyRequest() throws Exception
+    {
+        DefaultHttpClient httpclient = new DefaultHttpClient();
+        HttpGet httpGet = new HttpGet("http://localhost:9081/owbjetty9it/test.test");
+
+        HttpResponse response = httpclient.execute(httpGet);
+
+        // Get the response
+        BufferedReader rd = new BufferedReader
+                (new InputStreamReader(response.getEntity().getContent()));
+
+        StringBuilder builder = new StringBuilder();
+        String line = "";
+        while ((line = rd.readLine()) != null) {
+            builder.append(line);
+        }
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals("Got " + builder.toString(), 200, response.getStatusLine().getStatusCode());
+    }
+
+}

--- a/webbeans-jetty9/src/it/settings.xml
+++ b/webbeans-jetty9/src/it/settings.xml
@@ -20,6 +20,14 @@ under the License.
 -->
 
 <settings>
+  <mirrors>
+    <mirror>
+      <id>mrm-maven-plugin</id>
+      <name>Mock Repository Manager</name>
+      <url>@repository.proxy.url@</url>
+      <mirrorOf>*</mirrorOf>
+    </mirror>
+  </mirrors>
   <profiles>
     <profile>
       <id>it-repo</id>
@@ -29,24 +37,32 @@ under the License.
       <repositories>
         <repository>
           <id>local.central</id>
-          <url>@localRepositoryUrl@</url>
+          <url>@repository.proxy.url@</url>
           <releases>
             <enabled>true</enabled>
+            <checksumPolicy>ignore</checksumPolicy>
+            <updatePolicy>never</updatePolicy>
           </releases>
           <snapshots>
             <enabled>true</enabled>
+            <checksumPolicy>ignore</checksumPolicy>
+            <updatePolicy>always</updatePolicy>
           </snapshots>
         </repository>
       </repositories>
       <pluginRepositories>
         <pluginRepository>
           <id>local.central</id>
-          <url>@localRepositoryUrl@</url>
+          <url>@repository.proxy.url@</url>
           <releases>
             <enabled>true</enabled>
+            <checksumPolicy>ignore</checksumPolicy>
+            <updatePolicy>never</updatePolicy>
           </releases>
           <snapshots>
             <enabled>true</enabled>
+            <checksumPolicy>ignore</checksumPolicy>
+            <updatePolicy>always</updatePolicy>
           </snapshots>
         </pluginRepository>
       </pluginRepositories>

--- a/webbeans-jetty9/src/main/assembly/config.xml
+++ b/webbeans-jetty9/src/main/assembly/config.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<assembly>
+    <id>config</id>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/config</directory>
+            <outputDirectory></outputDirectory>
+            <includes>
+                <include>**</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/webbeans-jetty9/src/main/config/modules/apache-owb.mod
+++ b/webbeans-jetty9/src/main/config/modules/apache-owb.mod
@@ -13,9 +13,9 @@ maven://org.apache.openwebbeans/openwebbeans-impl/${apache-owb.version}|lib/apac
 maven://org.apache.openwebbeans/openwebbeans-web/${apache-owb.version}|lib/apache-owb/openwebbeans-web-${apache-owb.version}.jar
 maven://org.apache.openwebbeans/openwebbeans-el22/${apache-owb.version}|lib/apache-owb/openwebbeans-el22-${apache-owb.version}.jar
 maven://org.apache.openwebbeans/openwebbeans-jetty9/${apache-owb.version}|lib/apache-owb/openwebbeans-jetty9-${apache-owb.version}.jar
-maven://org.apache.geronimo.specs/geronimo-jcdi_2.0_spec/${geronimo-cdi-spec.version}|lib/apache-owb/geronimo-jcdi_2.0_spec-${geronimo-cdi-spec.version}.jar
-maven://org.apache.geronimo.specs/geronimo-atinject_1.0_spec/${geronimo-atinject-spec.version}|lib/apache-owb/geronimo-atinject_1.0_spec-${geronimo-atinject-spec.version}.jar
-maven://org.apache.geronimo.specs/geronimo-interceptor_1.2_spec/${geronimo-interceptor-spec.version}|lib/apache-owb/geronimo-interceptor_1.2_spec-${geronimo-interceptor-spec.version}.jar
+maven://org.apache.geronimo.specs/geronimo-jcdi_2.0_spec/${geronimo-cdi.version}|lib/apache-owb/geronimo-jcdi_2.0_spec-${geronimo-cdi.version}.jar
+maven://org.apache.geronimo.specs/geronimo-atinject_1.0_spec/${geronimo-atinject.version}|lib/apache-owb/geronimo-atinject_1.0_spec-${geronimo-atinject.version}.jar
+maven://org.apache.geronimo.specs/geronimo-interceptor_1.2_spec/${geronimo-interceptor.version}|lib/apache-owb/geronimo-interceptor_1.2_spec-${geronimo-interceptor.version}.jar
 maven://org.apache.xbean/xbean-finder-shaded/${xbean.version}|lib/apache-owb/xbean-finder-shaded-${xbean.version}.jar
 maven://org.apache.xbean/xbean-asm7-shaded/${xbean.version}|lib/apache-owb/xbean-asm7-shaded-${xbean.version}.jar
 
@@ -32,8 +32,8 @@ https://openwebbeans.apache.org/
 http://www.apache.org/licenses/LICENSE-2.0.html
 
 [ini]
-apache-owb.version?=2.0.11
-geronimo-cdi-spec.version=1.0
-geronimo-atinject-spec.version=1.0
-geronimo-interceptor-spec.version=1.0
-xbean.version=4.13
+apache-owb.version?=@project.version@
+geronimo-cdi.version=@geronimo_cdi.version@
+geronimo-atinject.version=@geronimo_atinject.version@
+geronimo-interceptor.version=@geronimo_interceptor.version@
+xbean.version=@xbean.version@


### PR DESCRIPTION
@struberg I found a way to integration test the jetty module. I also found a way to pull the dependency versions into the jetty module definition. With this I believe I am happy for a release