### PR TITLE
Unclear if we want to bump the dependency version and restrict users

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,7 @@
         <geronimo_interceptor.version>1.0</geronimo_interceptor.version>
         <geronimo_validation.version>1.1</geronimo_validation.version>
         <tomcat7.version>7.0.73</tomcat7.version>
-        <!-- jetty 9.4.13+ broke session persistence: https://github.com/eclipse/jetty.project/issues/3597 -->
-        <jetty.version>9.4.12.v20180830</jetty.version>
+        <jetty.version>9.4.18.v20190429</jetty.version>
         <myfaces.version>2.3.0</myfaces.version>
         <xbean.version>4.13</xbean.version>
         <arquillian.version>1.1.13.Final</arquillian.version>


### PR DESCRIPTION
On the other hand 9.4.18 is certainly better, but should we force it on consumers?