### PR TITLE
OWB-1298: Exclude Mojarra 2.3

### DIFF
--- a/webbeans-impl/src/main/resources/META-INF/openwebbeans/openwebbeans.properties
+++ b/webbeans-impl/src/main/resources/META-INF/openwebbeans/openwebbeans.properties
@@ -220,6 +220,7 @@ org.apache.webbeans.scanExclusionPaths=/jre/lib, \
         /jsp-api, \
         /myfaces-api, \
         /myfaces-impl, \
+        /jakarta.faces, \
         /servlet-api, \
         /javax, \
         /annotation-api, \


### PR DESCRIPTION
Using:
```
<dependency>
    <groupId>org.glassfish</groupId>
    <artifactId>jakarta.faces</artifactId>
    <version>2.3.16</version>
</dependency>
```

Prevents this issue:
```
org.apache.webbeans.exception.WebBeansDeploymentException: javax.enterprise.inject.AmbiguousResolutionException: There is more than one Bean with type com.sun.faces.push.WebsocketSessionManager Qualifiers: [@javax.enterprise.inject.Default()]
for injection into Field Injection Point, field name :  socketSessions, Bean Owner : [WebsocketPushContextProducer, WebBeansType:MANAGED, Name:null, API Types:[com.sun.faces.cdi.WebsocketPushContextProducer,java.lang.Object], Qualifiers:[javax.enterprise.inject.Default,javax.enterprise.inject.Any]]
found beans:
WebsocketSessionManager, WebBeansType:MANAGED, Name:null, API Types:[com.sun.faces.push.WebsocketSessionManager,java.lang.Object], Qualifiers:[javax.enterprise.inject.Default,javax.enterprise.inject.Any] from jar:file:/C:/dev/primefaces/primefaces-test/target/primefaces-test-1.0-SNAPSHOT/WEB-INF/lib/jakarta.faces-2.3.13.jar!/com/sun/faces/push/WebsocketSessionManager.class
WebsocketSessionManager, WebBeansType:MANAGED, Name:null, API Types:[com.sun.faces.push.WebsocketSessionManager,java.lang.Object], Qualifiers:[javax.enterprise.inject.Default,javax.enterprise.inject.Any] from jar:file:/C:/dev/primefaces/primefaces-test/target/primefaces-test-1.0-SNAPSHOT/WEB-INF/lib/jakarta.faces-2.3.13.jar!/com/sun/faces/push/WebsocketSessionManager.class
    at org.apache.webbeans.config.BeansDeployer.deploy (BeansDeployer.java:360)
    at org.apache.webbeans.lifecycle.AbstractLifeCycle.bootstrapApplication (AbstractLifeCycle.java:137)
    at org.apache.webbeans.lifecycle.AbstractLifeCycle.startApplication (AbstractLifeCycle.java:103)
    at org.apache.webbeans.web.lifecycle.WebContainerLifecycle.startApplication (WebContainerLifecycle.java:98)
    at org.apache.webbeans.servlet.WebBeansConfigurationListener.contextInitialized (WebBeansConfigurationListener.java:85)
    at org.eclipse.jetty.server.handler.ContextHandler.callContextInitialized (ContextHandler.java:921)
    at org.eclipse.jetty.servlet.ServletContextHandler.callContextInitialized (ServletContextHandler.java:554)
```