### PR TITLE
Improve handling of lineSeparator in ViolationMessageBuilder

### DIFF
--- a/webbeans-impl/src/main/java/org/apache/webbeans/exception/helper/ViolationMessageBuilder.java
+++ b/webbeans-impl/src/main/java/org/apache/webbeans/exception/helper/ViolationMessageBuilder.java
@@ -22,8 +22,6 @@ public class ViolationMessageBuilder
 {
     private StringBuilder violationMessage;
 
-    private final String lineSeparator = System.getProperty("line.separator");
-
     public static ViolationMessageBuilder newViolation()
     {
         return new ViolationMessageBuilder();
@@ -59,7 +57,7 @@ public class ViolationMessageBuilder
         }
         else if(appendLineSeparator)
         {
-            violationMessage.append(lineSeparator);
+            violationMessage.append(System.lineSeparator());
         }
 
         for(String t : text)


### PR DESCRIPTION
Call System.lineSeparator() instead of System.getProperty("line.separator") to avoid a potential bottleneck when multiple threads concurrently build violation messages and then have to synchronize on the HashMap access for System.getProperty.

The System class stores the lineSeparator as a static String and returns it in System.lineSeparator().