### PR TITLE
Fixed non determininstic(flaky) tests in BeanCacheKeyUnitTest.java

### DIFF
--- a/webbeans-impl/src/main/java/org/apache/webbeans/container/BeanCacheKey.java
+++ b/webbeans-impl/src/main/java/org/apache/webbeans/container/BeanCacheKey.java
@@ -294,9 +294,19 @@ public final class BeanCacheKey
 
             Method[] member1 = type1.getDeclaredMethods();
             Method[] member2 = type2.getDeclaredMethods();
-
+            
             // TBD: the order of the list of members seems to be deterministic
-
+            Comparator<Method> methodComparator = new Comparator<Method>() 
+            {
+                @Override
+                public int compare(Method o1, Method o2) 
+                {
+                    return o1.toString().compareTo(o2.toString());
+                }
+            };
+            Arrays.sort(member1, methodComparator);
+            Arrays.sort(member2, methodComparator);
+       
             int i = 0;
             int j = 0;
             int length1 = member1.length;


### PR DESCRIPTION
Hi,
I am from the Software Testing research group at the University of Illinois. We want to inform that the tests org.apache.webbeans.test.annotation.binding.BeanCacheKeyUnitTest.testEquals2Annotations and
org.apache.webbeans.test.annotation.binding.BeanCacheKeyUnitTest.testEquals2AnnotationsUnorderedParam are non deterministic. The non determinism has been discovered using the NonDex tool for catching non-deterministic/flaky tests (https://github.com/TestingResearchIllinois/NonDex).

You may reproduce the non deterministic behavior using the following steps:

- Clone the repo and cd into it.
- mvn install -am -pl webbeans-impl -DskipTests
- mvn -pl webbeans-impl test 
-Dtest=org.apache.webbeans.test.annotation.binding.BeanCacheKeyUnitTest#testEquals2Annotations 
- Confirm that the test passes as is.
mvn -pl webbeans-impl edu.illinois:nondex-maven-plugin:1.1.2:nondex 
-Dtest=rg.apache.webbeans.test.annotation.binding.BeanCacheKeyUnitTest#testEquals2Annotations  
- This will run the NonDex tool on the test. You will find the test fails.

Proposed fix:
As you have indicated in line 298 of BeanCacheKey.java, the order of list members are actually non determininstic because the nature of getDeclaredMethods(). I wrote a simple comparator that simply compares the describing string of the Method object, and sort the array based on that to make the order determininstic