### PR TITLE
Try/catch so we don't fail if @New is missing

### DIFF
--- a/webbeans-impl/src/main/java/org/apache/webbeans/container/InjectionResolver.java
+++ b/webbeans-impl/src/main/java/org/apache/webbeans/container/InjectionResolver.java
@@ -571,23 +571,29 @@ public class InjectionResolver
 
     private void findNewBean(Set<Bean<?>> resolvedComponents, Type injectionPointType, Annotation[] qualifiers)
     {
-        if (qualifiers.length == 1 && New.class.equals(qualifiers[0].annotationType()))
+        try
         {
-            // happen in TCKs, shouldn't be the case in real apps
-            New newQualifier = (New)qualifiers[0];
-            Class<?> beanClass;
-            if (newQualifier.value() != New.class)
+            if (qualifiers.length == 1 && New.class.equals(qualifiers[0].annotationType()))
             {
-                beanClass = newQualifier.value();
-            }
-            else
-            {
-                beanClass = GenericsUtil.getRawType(injectionPointType);
-            }
+                // happen in TCKs, shouldn't be the case in real apps
+                New newQualifier = (New) qualifiers[0];
+                Class<?> beanClass;
+                if (newQualifier.value() != New.class)
+                {
+                    beanClass = newQualifier.value();
+                }
+                else
+                {
+                    beanClass = GenericsUtil.getRawType(injectionPointType);
+                }
 
-            resolvedComponents.add(webBeansContext.getWebBeansUtil().createNewComponent(beanClass));
+                resolvedComponents.add(webBeansContext.getWebBeansUtil().createNewComponent(beanClass));
+            }
         }
-
+        catch (NoClassDefFoundError e)
+        {
+            logger.log(Level.FINE, "DEBUG_NEW_ANNOTATION_MISSING", e);
+        }
     }
 
     private Set<Bean<?>> findByBeanType(Set<Bean<?>> allComponents, Type injectionPointType, boolean isDelegate)

--- a/webbeans-impl/src/main/resources/openwebbeans/Messages.properties
+++ b/webbeans-impl/src/main/resources/openwebbeans/Messages.properties
@@ -115,5 +115,6 @@ EXCEPT_0018 = Wrong startup object.
 
 DEBUG_ADD_BYTYPE_CACHE_BEANS = Adding resolved beans with key [{0}] to cache.
 DEBUG_ADD_BYNAME_CACHE_BEANS = Adding resolved EL beans with key [{0}] to cache.
- 
+DEBUG_NEW_ANNOTATION_MISSING = @New annotation missing. This was deprecated in CDI 1.1, and removed in CDI 4.0. Skipping.
+
 #========= END OF TRANSLATED MESSAGES =================================


### PR DESCRIPTION
The `@New` annotation has been deprecated for while, and removed in CDI 4. This PR allows OWB to skip rather than fail with an error if `@New` is not available on the classpath.